### PR TITLE
Add basic Pomodoro timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pomodoro Timer</title>
+</head>
+<body>
+    <h1>Pomodoro</h1>
+    <div id="timer">25:00</div>
+    <button id="start">Iniciar</button>
+    <button id="reset">Reiniciar</button>
+    <script src="index.js"></script>
+    <script>
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/sw.js');
+    }
+    </script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,40 @@
+const duration = 25 * 60; // duración en segundos
+let remaining = duration;
+let interval = null;
+
+const display = document.getElementById('timer');
+const startBtn = document.getElementById('start');
+const resetBtn = document.getElementById('reset');
+
+function updateDisplay() {
+    const minutes = String(Math.floor(remaining / 60)).padStart(2, '0');
+    const seconds = String(remaining % 60).padStart(2, '0');
+    display.textContent = `${minutes}:${seconds}`;
+}
+
+function start() {
+    if (interval) return;
+    interval = setInterval(() => {
+        remaining--;
+        updateDisplay();
+        if (remaining <= 0) {
+            clearInterval(interval);
+            interval = null;
+            remaining = duration;
+            alert('¡Tiempo terminado!');
+            updateDisplay();
+        }
+    }, 1000);
+}
+
+function reset() {
+    clearInterval(interval);
+    interval = null;
+    remaining = duration;
+    updateDisplay();
+}
+
+startBtn.addEventListener('click', start);
+resetBtn.addEventListener('click', reset);
+
+updateDisplay();

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,8 @@ self.addEventListener('install', (event) => {
         caches.open('pomodoro-timer').then((cache) => {
             return cache.addAll([
                 '/',
-                '/index.html'
+                '/index.html',
+                '/index.js'
             ]);
         })
     );


### PR DESCRIPTION
## Summary
- Create simple Pomodoro timer UI with start/reset controls
- Implement timer logic and register service worker
- Extend service worker cache to include timer assets

## Testing
- `node --check index.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0d6e9af0832dbbcf43e1f1f3ae51